### PR TITLE
HttpResponse fix

### DIFF
--- a/src/com/github/tncrazvan/catpaw/http/HttpResponse.php
+++ b/src/com/github/tncrazvan/catpaw/http/HttpResponse.php
@@ -30,10 +30,10 @@ class HttpResponse{
     }
 
     public function &getBody(){
-        if(\is_array($this->body) || \is_object($this->body)){
+        /*if(\is_array($this->body) || \is_object($this->body)){
             $result = json_encode($this->body);
             return $result;
-        }
+        }*/
         return $this->body;
     }
 


### PR DESCRIPTION
Fixed an issue with HttpResponse which cause the server to skip the parsing of the user "Accept" header and always return a json object.

The server should now correctly conver all responses to json,txt,or xml as requested by the user regardless of what the data on the server looks like.