### PR TITLE
funcheck completely removed from HttpEventListener

### DIFF
--- a/src/com/github/tncrazvan/catpaw/CatPaw.php
+++ b/src/com/github/tncrazvan/catpaw/CatPaw.php
@@ -256,7 +256,7 @@ class CatPaw{
                         try{
                             $responseObject = $e->generator->getReturn();
                             $e->generator = null;
-                            $e->funcheck($responseObject);
+                            //$e->funcheck($responseObject);
                             $e->dispatch($responseObject);
                         }catch(\Exception $ex){
                             $e->generator = null;

--- a/src/com/github/tncrazvan/catpaw/http/HttpEventListener.php
+++ b/src/com/github/tncrazvan/catpaw/http/HttpEventListener.php
@@ -157,7 +157,7 @@ class HttpEventListener{
                 ],$ex->getMessage()."\n".$ex->getTraceAsString());
             }
             if($error){
-                $this->event->funcheck($this->event->responseObject);
+                //$this->event->funcheck($this->event->responseObject);
                 $this->event->dispatch($this->event->responseObject);
                 return false;
             }else 

--- a/src/com/github/tncrazvan/catpaw/http/HttpEventManager.php
+++ b/src/com/github/tncrazvan/catpaw/http/HttpEventManager.php
@@ -151,7 +151,7 @@ abstract class HttpEventManager extends EventManager{
         return true;
     }
 
-    public function funcheck(&$responseObject){
+    /* public function funcheck(&$responseObject){
         while($responseObject instanceof HttpEventHandler){
             if(
                 $responseObject instanceof HttpMethodGet
@@ -192,7 +192,7 @@ abstract class HttpEventManager extends EventManager{
                 ]);
             }
         }
-    }
+    } */
 
     private function adaptHeadersAndBody(array &$accepts,&$body):void{
         foreach($accepts as &$accept){


### PR DESCRIPTION
HttpEventListener will no longer check for object like events.
The new Route helper class will do that job now instead.

This will make the codebase more coherent as events will ALWAYS be functions callbacks.