### PR TITLE
2.0.6

### DIFF
--- a/src/com/github/tncrazvan/catpaw/EventManager.php
+++ b/src/com/github/tncrazvan/catpaw/EventManager.php
@@ -142,7 +142,11 @@ abstract class EventManager{
                     $params[] = &$param;
                 break;
                 case \Closure::class:
-                    $params[] = $this->_commit_fn;
+                    $name = $parameter->getName();
+                    if('commit' === $name)
+                        $params[] = $this->_commit_fn;
+                    else
+                        $params[] = function(){};
                 break;
                 case 'string':
                     $name = $parameter->getName();

--- a/src/com/github/tncrazvan/catpaw/http/HttpResponseCookies.php
+++ b/src/com/github/tncrazvan/catpaw/http/HttpResponseCookies.php
@@ -11,7 +11,7 @@ class HttpResponseCookies{
         $this->event->setResponseCookie($key,$content,$path,$domain,$expire);
     }
 
-    public function unset(string $key, ?string $path, ?string $domain):void{
+    public function unset(string $key, ?string $path = '/', ?string $domain = null):void{
         $this->event->unsetResponseCookie($key,$path,$domain);
     }
 


### PR DESCRIPTION
```\Closure $commit``` injection implemented.
Check https://github.com/tncrazvan/catpaw-template/wiki/B.1-Yield,-HttpResponse-&-Commits for more information.