### PR TITLE
Routing moved to Attributes implementation with Php 8

### DIFF
--- a/src/com/github/tncrazvan/catpaw/attributes/COPY.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/COPY.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class COPY{}

--- a/src/com/github/tncrazvan/catpaw/attributes/DELETE.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/DELETE.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class DELETE{}

--- a/src/com/github/tncrazvan/catpaw/attributes/GET.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/GET.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class GET{}

--- a/src/com/github/tncrazvan/catpaw/attributes/HEAD.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/HEAD.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class HEAD{}

--- a/src/com/github/tncrazvan/catpaw/attributes/LINK.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/LINK.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class LINK{}

--- a/src/com/github/tncrazvan/catpaw/attributes/LOCK.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/LOCK.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class LOCK{}

--- a/src/com/github/tncrazvan/catpaw/attributes/OPTIONS.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/OPTIONS.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class OPTIONS{}

--- a/src/com/github/tncrazvan/catpaw/attributes/PATCH.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/PATCH.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class PATCH{}

--- a/src/com/github/tncrazvan/catpaw/attributes/POST.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/POST.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class POST{}

--- a/src/com/github/tncrazvan/catpaw/attributes/PROPFIND.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/PROPFIND.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class PROPFIND{}

--- a/src/com/github/tncrazvan/catpaw/attributes/PURGE.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/PURGE.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class PURGE{}

--- a/src/com/github/tncrazvan/catpaw/attributes/PUT.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/PUT.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class PUT{}

--- a/src/com/github/tncrazvan/catpaw/attributes/Path.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/Path.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class Path{}

--- a/src/com/github/tncrazvan/catpaw/attributes/UNKNOWN.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/UNKNOWN.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class UNKNOWN{}

--- a/src/com/github/tncrazvan/catpaw/attributes/UNLINK.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/UNLINK.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class UNLINK{}

--- a/src/com/github/tncrazvan/catpaw/attributes/UNLOCK.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/UNLOCK.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class UNLOCK{}

--- a/src/com/github/tncrazvan/catpaw/attributes/VIEW.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/VIEW.php
@@ -1,0 +1,4 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes;
+#[Attribute]
+class VIEW{}

--- a/src/com/github/tncrazvan/catpaw/http/HttpEventHandler.php
+++ b/src/com/github/tncrazvan/catpaw/http/HttpEventHandler.php
@@ -10,7 +10,7 @@ abstract class HttpEventHandler{
      * @param string $functionName name of the local function.
      * @return array an array that contains metadata for this registration.
      */
-    protected static function target(string $method, string $path, string $functionName):array{
+    public static function target(string $method, string $path, string $functionName):array{
         
         $path = \preg_replace('/^\/+/','',$path);
         


### PR DESCRIPTION
- ```HttpHandler``` is now deprecated.
All class based routing should be implemented through Attributes.
Documentation will be updated accordingly soon.

- ```@404``` default events changed.
Php scripts will not be executed anymore by the default ```@404``` event handler for security reasons (this includes all ```index.php``` files)
Php scripts will have to be implemented manually through ```ServerFile::include```.