### PR TITLE
Added a few Entity attributes and examples

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	"autoload": {
 		"psr-4": {
 			"com\\github\\tncrazvan\\catpaw\\":["src/com/github/tncrazvan/catpaw/"],
-			"app\\":["app/"]
+			"examples\\":["examples/"]
 		}
 	}
 }

--- a/examples/DBTasks.php
+++ b/examples/DBTasks.php
@@ -1,0 +1,94 @@
+<?php
+namespace examples;
+
+use com\github\tncrazvan\catpaw\attributes\Body;
+use com\github\tncrazvan\catpaw\attributes\Consumes;
+use com\github\tncrazvan\catpaw\attributes\Filter;
+use com\github\tncrazvan\catpaw\attributes\http\methods\GET;
+use com\github\tncrazvan\catpaw\attributes\http\methods\POST;
+use com\github\tncrazvan\catpaw\attributes\http\methods\PUT;
+use com\github\tncrazvan\catpaw\attributes\http\Path;
+use com\github\tncrazvan\catpaw\attributes\Inject;
+use com\github\tncrazvan\catpaw\attributes\Produces;
+use com\github\tncrazvan\catpaw\tools\Status;
+use examples\filters\AssertTaskExists;
+use examples\filters\CheckTaskTitleLength;
+use examples\models\Task;
+use examples\repositories\TaskRepository;
+use Generator;
+
+
+#[Path("/tasks")]                           //specify the http base path.
+                                            //all web methods within this class will 
+                                            // prepend "/todo" to their path.
+                                            //you can also specify path parameters in this base path,
+                                            //which will be inherited by the web method paths below.
+class DBTasks{
+
+    #[GET]                                  //specify the http method
+    #[Produces("application/json")]         //specify what type of content this method produces
+                                            //by default this is "text/plain".
+                                            //note that if this does not match with the "Accept" header
+                                            //of the request the request will fail.
+                                            //you can specify multiple types like so:
+                                            //#[Produces("application/json,text/plain,application/xml")]
+    public function findAllTasks(
+        #[Inject] TaskRepository $repo      //inject the repository
+    ):Generator|array{                      //specify it's a generator so that intellisense won't scream at you
+        
+        $tasks = yield $repo->findAll();    //find the todos from the database and `yield`.
+                                            //`yield`ing will make it so the server will convert the 
+                                            //response of this method to a `Promise` in the background.
+                                            //This means that from this point on your method has become
+                                            //an asynchronous method, everytime you `yield` execution will be paused
+                                            //and resumed on the next loop tick.
+                                            //Note that you don't have to provide an instance of the loop object,
+                                            //that's because loop itself is a singleton which the server can recover easily.
+
+        return $tasks;                      //return the todos.
+    }
+
+    #[POST]
+    #[Consumes("application/json")]         //specify it consumes json data.
+                                            //this means user MUST send an "Content-Type: application/json" header.
+                                            //in the request.
+    
+    #[Filter(CheckTaskTitleLength::class)]       //filter the request.
+                                            //this filter will mae sure that the task, for example, has a title
+                                            //long at least 10 characters.
+    public function addNewTask(
+        #[Inject] TaskRepository $repo,
+        #[Status] Status $status,
+        #[Body] Task $task                  //cast the data into a `Task` object.
+    ):string{
+        $task->id = null;                   //make sure the `id` is null so that mysql
+                                            //will provide this value instead.
+        $repo->save($task);
+        $status->setCode(Status::CREATED);
+        return "Task added.";
+    }
+
+    ###################################################################
+    #                                                                 #
+    #  much of what is going on in this PUT endpoint is the same as   #
+    #  what is going on in the above POST endpoint.                   #
+    #                                                                 #
+    ###################################################################
+    #[PUT]
+    #[Consumes("application/json")]
+    #[Filter(
+        CheckTaskTitleLength::class,    //make sure the new task title is at least
+                                        //10 characters long
+
+        AssertTaskExists::class         //make sure the task exists before even trying
+                                        //to update it
+    )]
+    public function updateTask(
+        #[Inject] TaskRepository $repo,
+        #[Body] Task $task
+    ):Generator|string{
+        $task->updated = time();
+        $repo->update($task);           //update task
+        return "Task updated.";
+    }
+}

--- a/examples/Server.php
+++ b/examples/Server.php
@@ -1,5 +1,5 @@
 <?php
-namespace app;
+namespace examples;
 
 use com\github\tncrazvan\catpaw\attributes\Entry;
 use com\github\tncrazvan\catpaw\attributes\Filter;

--- a/examples/Starter.php
+++ b/examples/Starter.php
@@ -1,5 +1,5 @@
 <?php
-namespace app;
+namespace examples;
 
 use com\github\tncrazvan\catpaw\attributes\ApplicationScoped;
 use com\github\tncrazvan\catpaw\attributes\Entry;
@@ -9,7 +9,7 @@ use React\Promise\Promise;
 class Starter{
     #[Entry]
     public function main(){
-        $hello = yield new Promise(fn($r)=>$r("hello!!!!\n"));
+        $hello = yield new Promise(fn($r)=>$r("Hello this from Promise!\n"));
         echo $hello;
     }
 }

--- a/examples/YieldTest.php
+++ b/examples/YieldTest.php
@@ -1,0 +1,17 @@
+<?php
+namespace examples;
+
+use com\github\tncrazvan\catpaw\attributes\http\methods\GET;
+use com\github\tncrazvan\catpaw\attributes\http\Path;
+use React\Promise\Promise;
+
+#[Path("/yield")]
+class YieldTest{
+    #[GET]
+    public function test():\Generator|string{
+        $user = yield new Promise(function($r){
+            $r("my cool username");
+        });
+        return $user;
+    }
+}

--- a/examples/db-dump/DatabaseTest.mysql.sql
+++ b/examples/db-dump/DatabaseTest.mysql.sql
@@ -1,0 +1,9 @@
+create database if not exists todos;
+use todos;
+create table if not exists task(
+    `id` int unsigned primary key auto_increment,
+    `title` varchar(255) not null default '',
+    `description` text not null default '',
+    `created` int unsigned not null default 0,
+    `updated` int unsigned not null default 0
+);

--- a/examples/filters/AssertTaskExists.php
+++ b/examples/filters/AssertTaskExists.php
@@ -1,0 +1,32 @@
+<?php
+namespace examples\filters;
+
+use com\github\tncrazvan\catpaw\attributes\Body;
+use com\github\tncrazvan\catpaw\attributes\Consumes;
+use com\github\tncrazvan\catpaw\attributes\Entry;
+use com\github\tncrazvan\catpaw\attributes\FilterItem;
+use com\github\tncrazvan\catpaw\attributes\Inject;
+use com\github\tncrazvan\catpaw\tools\Status;
+use examples\models\Task;
+use examples\repositories\TaskRepository;
+
+#[FilterItem]
+class AssertTaskExists{
+
+    #[Entry]
+    #[Consumes("application/json")]
+    public function check(
+        #[Body] Task $task,
+        #[Status] Status $status,
+        #[Inject] TaskRepository $repo
+    ){
+        $dbtask = $repo->findById($task->id);   
+        if(!$dbtask){
+            $status->setCode(Status::PRECONDITION_FAILED);
+            return "Task {$task->id} does not exist.";
+        }
+
+        return null;    //task passed through the filter
+    }
+
+}

--- a/examples/filters/CheckTaskTitleLength.php
+++ b/examples/filters/CheckTaskTitleLength.php
@@ -1,0 +1,29 @@
+<?php
+namespace examples\filters;
+
+use com\github\tncrazvan\catpaw\attributes\Body;
+use com\github\tncrazvan\catpaw\attributes\Consumes;
+use com\github\tncrazvan\catpaw\attributes\Entry;
+use com\github\tncrazvan\catpaw\attributes\FilterItem;
+use com\github\tncrazvan\catpaw\attributes\Inject;
+use com\github\tncrazvan\catpaw\tools\Status;
+use examples\models\Task;
+
+#[FilterItem]
+class CheckTaskTitleLength{
+
+    #[Entry]
+    #[Consumes("application/json")]
+    public function check(
+        #[Body] Task $task,
+        #[Status] Status $status
+    ){
+        if(strlen($task->title) < 10){
+            $status->setCode(Status::PRECONDITION_FAILED);
+            return "Task title must be at least 10 characters long.";   //task was blocked by the filter
+        }
+
+        return null;    //task passed through the filter
+    }
+
+}

--- a/examples/models/Task.php
+++ b/examples/models/Task.php
@@ -1,0 +1,27 @@
+<?php
+namespace examples\models;
+
+use com\github\tncrazvan\catpaw\attributes\database\Column;
+use com\github\tncrazvan\catpaw\attributes\database\Id;
+use com\github\tncrazvan\catpaw\attributes\database\IgnoreUpdate;
+use com\github\tncrazvan\catpaw\tools\helpers\Entity;
+//use PDO;
+
+#[Entity]
+class Task{
+    #[Id] public ?int $id = null;                   //null by default, so that mysql autoincrements is
+                                                    //you can also specify the type  manually 
+                                                    //by using #[ID(PDO::PARAM_**)]
+    #[Column] public string $title = '';
+    #[Column] public string $description = '';
+
+    #[IgnoreUpdate]                                 //this will make it so that the `created` column
+                                                    //will not be set when `update`ing the entity.
+    #[Column] public int $created;
+    #[Column] public int $updated;
+
+    public function __construct(){
+        $this->created = time();
+        $this->updated = $this->created;
+    }
+}

--- a/examples/repositories/TaskRepository.php
+++ b/examples/repositories/TaskRepository.php
@@ -1,0 +1,31 @@
+<?php
+namespace examples\repositories;
+
+use com\github\tncrazvan\catpaw\attributes\Repository;
+use com\github\tncrazvan\catpaw\qb\operations\Operation;
+use com\github\tncrazvan\catpaw\qb\tools\Column;
+use com\github\tncrazvan\catpaw\tools\helpers\CrudRepository;
+use examples\models\Task;
+
+#[Repository(Task::class)]          //specify that this is a repository for the `Todo` model.
+                                    //this way the repository knows whic tables to query and what
+                                    //the collumns are.
+                                    //also this class is now injectable as a singleton.
+class TaskRepository 
+    extends CrudRepository          //this will provide some basic crud operations
+                                    //and the simple query builder we instantiated as a singleton
+                                    //in the beginning in `main.php`
+    {
+        public function update(Task $task):void{
+            $this
+                ->builder
+                ->update(Task::class,$task)
+                ->where()
+                ->column('id',Column::EQUALS,$task->id)
+                ->execute()
+                ;
+        }
+
+        //nothing else to do here, this repository already has the basic
+        //functionalities of CRUD because of `extends CrudRepository`.
+}

--- a/main.php
+++ b/main.php
@@ -4,14 +4,38 @@ require_once './vendor/autoload.php';
 use com\github\tncrazvan\catpaw\CatPaw;
 use com\github\tncrazvan\catpaw\config\MainConfiguration;
 use com\github\tncrazvan\catpaw\tools\helpers\Factory;
+use com\github\tncrazvan\catpaw\tools\helpers\SimpleQueryBuilder;
 use React\EventLoop\LoopInterface;
 
+//make a new loop and make it injectable
 Factory::setObject(LoopInterface::class,\React\EventLoop\Factory::create());
 
-Factory::make(\app\Server::class);
-Factory::make(\app\YieldTest::class);
-Factory::make(\app\Starter::class);
+//make a new simple query builder using a PDO connection and make it injectable
+Factory::setObject(
+    SimpleQueryBuilder::class,new SimpleQueryBuilder(
+        new \PDO(                                       //make the pdo object
+            "mysql:"                                    //dsn
+            ."host=localhost;"
+            ."dbname=todos;"
+            ."port=3306;"
+            ."charset=utf8mb4;",
+            "razshare",                                 //username
+            "razshare"                                  //password
+        ),
+        Factory::make(LoopInterface::class)             //Inject the loop that has just been created above
+    )
+);
 
+//scan classes
+//using `cat-template`, this can will be done automatically for you.
+Factory::make(\examples\Server::class);
+Factory::make(\examples\YieldTest::class);
+Factory::make(\examples\Starter::class);
+Factory::make(\examples\repositories\TaskRepository::class);
+Factory::make(\examples\models\Task::class);
+Factory::make(\examples\DBTasks::class);
+
+//create and start server
 $server = new CatPaw(new class extends MainConfiguration{
     public function __construct() {
         $this->show_exception = true;

--- a/src/com/github/tncrazvan/catpaw/attributes/database/IgnoreInsert.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/database/IgnoreInsert.php
@@ -1,0 +1,13 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes\database;
+
+use com\github\tncrazvan\catpaw\attributes\interfaces\AttributeInterface;
+use com\github\tncrazvan\catpaw\attributes\traits\CoreAttributeDefinition;
+
+/**
+ * Ignore this column when building an `insert` query.
+ */
+#[\Attribute]
+class IgnoreInsert implements AttributeInterface{
+    use CoreAttributeDefinition;
+}

--- a/src/com/github/tncrazvan/catpaw/attributes/database/IgnoreSelect.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/database/IgnoreSelect.php
@@ -1,0 +1,13 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes\database;
+
+use com\github\tncrazvan\catpaw\attributes\interfaces\AttributeInterface;
+use com\github\tncrazvan\catpaw\attributes\traits\CoreAttributeDefinition;
+
+/**
+ * Ignore this column when building a `select` query.
+ */
+#[\Attribute]
+class IgnoreSelect implements AttributeInterface{
+    use CoreAttributeDefinition;
+}

--- a/src/com/github/tncrazvan/catpaw/attributes/database/IgnoreUpdate.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/database/IgnoreUpdate.php
@@ -1,0 +1,13 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes\database;
+
+use com\github\tncrazvan\catpaw\attributes\interfaces\AttributeInterface;
+use com\github\tncrazvan\catpaw\attributes\traits\CoreAttributeDefinition;
+
+/**
+ * Ignore this column when building an `update` query.
+ */
+#[\Attribute]
+class IgnoreUpdate implements AttributeInterface{
+    use CoreAttributeDefinition;
+}

--- a/src/com/github/tncrazvan/catpaw/qb/tools/CoreEntity.php
+++ b/src/com/github/tncrazvan/catpaw/qb/tools/CoreEntity.php
@@ -7,14 +7,15 @@ use com\github\tncrazvan\catpaw\qb\traits\EntitySyncFromProps;
 abstract class CoreEntity extends EntityDefinition{
     use EntitySyncFromProps;
 
-    private array $savedColumns = [];
-    private array $aliasColumns = [];
+    protected array $savedColumns = [];
+    protected array $aliasColumns = [];
+    
     public function __construct(){
         //static::_sync_entity_columns_from_props($this);
     }
     
-    public function reset_columns():void{
-        foreach($this->columns() as $name => &$type){
+    public function reset_columns(int $domain = 0):void{
+        foreach($this->columns($domain) as $name => &$type){
             $this->savedColumns[$name] = new Column($name,$type,false,(\in_array($name,$this->primaryKeys()))?true:false);
             $this->config($this->savedColumns[$name]);
         }
@@ -26,16 +27,26 @@ abstract class CoreEntity extends EntityDefinition{
      * Get the columns of this entity
      * @return array an array of Column objects
      */
-    public function &getEntityColumns():array{
-        return $this->savedColumns;
+    public function &getEntityColumns(int $domain = 0):array{
+        $columns = [];
+        foreach($this->columns($domain) as $name => &$column){
+            if(isset($this->savedColumns[$name]))
+                $columns[$name] = $this->savedColumns[$name];
+        }
+        return $columns;
     }
 
     /**
      * Get the columns of this entity
      * @return array an array of Column objects
      */
-    public function &getEntityAliasColumns():array{
-        return $this->aliasColumns;
+    public function &getEntityAliasColumns(int $domain = 0):array{
+        $columns = [];
+        foreach($this->columns($domain) as $name => &$column){
+            if(isset($this->aliasColumns[$name]))
+                $columns[$name] = $this->aliasColumns[$name];
+        }
+        return $columns;
     }
 
     /**

--- a/src/com/github/tncrazvan/catpaw/qb/tools/abstracts/EntityDefinition.php
+++ b/src/com/github/tncrazvan/catpaw/qb/tools/abstracts/EntityDefinition.php
@@ -2,7 +2,7 @@
 namespace com\github\tncrazvan\catpaw\qb\tools\abstracts;
 
 abstract class EntityDefinition{
-    public abstract function columns():array;
+    public abstract function columns(int $domain = 0):array;
     public abstract function primaryKeys():array;
     public abstract function tableName():string;
 }

--- a/src/com/github/tncrazvan/catpaw/qb/traits/Insert.php
+++ b/src/com/github/tncrazvan/catpaw/qb/traits/Insert.php
@@ -8,6 +8,7 @@ use com\github\tncrazvan\catpaw\qb\tools\CoreEntity;
 use com\github\tncrazvan\catpaw\qb\tools\QueryBuilder;
 use com\github\tncrazvan\catpaw\qb\tools\interfaces\IntoCallback;
 use com\github\tncrazvan\catpaw\qb\tools\QueryConst;
+use com\github\tncrazvan\catpaw\tools\helpers\Entity;
 
 trait Insert{
     private ?IntoCallback $default_into_callback = null;
@@ -51,7 +52,7 @@ trait Insert{
         $entity_r = Factory::make($classname);
         $this->add(QueryConst::INTO);
         $this->add($entity_r->tableName());
-        $this->mapColumns($entity_r->getEntityColumns());
+        $this->mapColumns($entity_r->getEntityColumns(Entity::FOR_INSERT));
         if($cloning){
             $clone = clone($object);
             $results = $callback->run($clone);
@@ -97,7 +98,7 @@ trait Insert{
      * @return QueryBuilder the QueryBuilder
      */
     private function value(CoreEntity $entity, object &$object):QueryBuilder{
-        $columns = &$entity->getEntityColumns();
+        $columns = &$entity->getEntityColumns(Entity::FOR_INSERT);
         $random = '';
         $vname = '';
         $this->add(QueryConst::PARENTHESIS_LEFT);

--- a/src/com/github/tncrazvan/catpaw/qb/traits/Join.php
+++ b/src/com/github/tncrazvan/catpaw/qb/traits/Join.php
@@ -8,6 +8,7 @@ use com\github\tncrazvan\catpaw\qb\tools\CoreEntity;
 use com\github\tncrazvan\catpaw\qb\tools\Repository;
 use com\github\tncrazvan\catpaw\qb\tools\QueryConst;
 use com\github\tncrazvan\catpaw\qb\tools\QueryBuilder;
+use com\github\tncrazvan\catpaw\tools\helpers\Entity;
 
 trait Join{
     //private $joins = [];
@@ -27,7 +28,7 @@ trait Join{
         if($as !== null){
             $this->add(QueryConst::AS);
             $this->add($as);
-            $columnsRef = &$entity->getEntityAliasColumns();
+            $columnsRef = &$entity->getEntityAliasColumns(Entity::FOR_SELECT);
             $columns = $columnsRef;
             foreach($columns as $key => &$column){
                 $columnsRef[$as.QueryConst::PERIOD.$key] = $column; 
@@ -123,7 +124,7 @@ trait Join{
 
         if(!$and) $this->add(QueryConst::ON);
         $this->add($columnName);
-        $operation = $callback->run($entity->getEntityColumns()[$columnName]);
+        $operation = $callback->run($entity->getEntityColumns(Entity::FOR_SELECT)[$columnName]);
         $this->add($operation->toString());
         return $this;
     }

--- a/src/com/github/tncrazvan/catpaw/qb/traits/Select.php
+++ b/src/com/github/tncrazvan/catpaw/qb/traits/Select.php
@@ -5,6 +5,7 @@ namespace com\github\tncrazvan\catpaw\qb\traits;
 use com\github\tncrazvan\catpaw\tools\helpers\Factory;
 use com\github\tncrazvan\catpaw\qb\tools\QueryBuilder;
 use com\github\tncrazvan\catpaw\qb\tools\QueryConst;
+use com\github\tncrazvan\catpaw\tools\helpers\Entity;
 
 trait Select{
 
@@ -15,7 +16,7 @@ trait Select{
      */
     public function select(string $classname):QueryBuilder{
         $entity_r = Factory::make($classname);
-        $this->selectColumns(...\array_keys($entity_r->columns()));
+        $this->selectColumns(...\array_keys($entity_r->columns(Entity::FOR_SELECT)));
         $this->from($classname);
         return $this;
     }

--- a/src/com/github/tncrazvan/catpaw/qb/traits/Update.php
+++ b/src/com/github/tncrazvan/catpaw/qb/traits/Update.php
@@ -8,19 +8,20 @@ use com\github\tncrazvan\catpaw\qb\tools\Column;
 use com\github\tncrazvan\catpaw\qb\tools\CoreEntity;
 use com\github\tncrazvan\catpaw\qb\tools\QueryBuilder;
 use com\github\tncrazvan\catpaw\qb\tools\QueryConst;
+use com\github\tncrazvan\catpaw\tools\helpers\Entity;
 
 trait Update{
-    public function update(string $classname, object $object):QueryBuilder{
-        $this->current_classname = $classname;
+    public function update(string $classname, object $object):QueryBuilder{  
         $entity_r = Factory::make($classname);
         CoreEntity::_sync_entity_columns_from_props($entity_r,$object);
         $this->reset();
+        $this->current_classname = $classname;
         $random = '';
         $this->add(QueryConst::UPDATE);
         $this->add($entity_r->tableName());
         $this->add(QueryConst::SET);
         
-        $columns = \array_merge($entity_r->getEntityColumns(),$entity_r->getEntityAliasColumns());
+        $columns = \array_merge($entity_r->getEntityColumns(Entity::FOR_UPDATE),$entity_r->getEntityAliasColumns(Entity::FOR_UPDATE));
         
         //$length = \count($columns);
 

--- a/src/com/github/tncrazvan/catpaw/tools/helpers/Entity.php
+++ b/src/com/github/tncrazvan/catpaw/tools/helpers/Entity.php
@@ -3,22 +3,39 @@ namespace com\github\tncrazvan\catpaw\tools\helpers;
 
 use com\github\tncrazvan\catpaw\attributes\interfaces\AttributeInterface;
 use com\github\tncrazvan\catpaw\attributes\traits\CoreAttributeDefinition;
+use com\github\tncrazvan\catpaw\qb\tools\Column;
 use com\github\tncrazvan\catpaw\qb\tools\CoreEntity;
 
 #[\Attribute]
 class Entity extends CoreEntity implements AttributeInterface{
     use CoreAttributeDefinition;
     private array $columns = [];
+    private array $columnsForInsert = [];
+    private array $columnsForUpdate = [];
+    private array $columnsForSelect = [];
     private array $primaryKeys = [];
     private string $tableName = '';
+    public const ALL = 0;
+    public const FOR_INSERT = 1;
+    public const FOR_UPDATE = 2;
+    public const FOR_SELECT = 3;
 
     public function __construct(string $tableName = '') {
         $this->tableName = $tableName;
     }
 
-    public function columns():array{
+    public function columns(int $domain = 0):array{
+        switch($domain){
+            case static::FOR_INSERT:
+                return $this->columnsForInsert;
+            case static::FOR_UPDATE:
+                return $this->columnsForUpdate;
+            case static::FOR_SELECT:
+                return $this->columnsForSelect;
+        }
         return $this->columns;
     }
+
     public function primaryKeys():array{
         return $this->primaryKeys;
     }
@@ -29,6 +46,15 @@ class Entity extends CoreEntity implements AttributeInterface{
     public function setColumns(array $columns):void{
         $this->columns = $columns;
     }
+    public function setColumnsForInsert(array $columns):void{
+        $this->columnsForInsert = $columns;
+    }
+    public function setColumnsForUpdate(array $columns):void{
+        $this->columnsForUpdate = $columns;
+    }
+    public function setColumnsForSelect(array $columns):void{
+        $this->columnsForSelect = $columns;
+    }
 
     public function setPrimaryKeys(array $primaryKeys):void{
         $this->primaryKeys = $primaryKeys;
@@ -36,5 +62,16 @@ class Entity extends CoreEntity implements AttributeInterface{
 
     public function setTableName(string $tableName):void{
         $this->tableName = $tableName;
+    }
+
+    public function ignoreColumnForDomain(string $colName, int $domain):void{
+        switch($domain){
+            case static::FOR_INSERT:
+                unset($this->columnsForInsert[$colName]);
+            break;
+            case static::FOR_UPDATE:
+                unset($this->columnsForInsert[$colName]);
+            break;
+        }
     }
 }

--- a/src/com/github/tncrazvan/catpaw/tools/helpers/Factory.php
+++ b/src/com/github/tncrazvan/catpaw/tools/helpers/Factory.php
@@ -6,6 +6,9 @@ use com\github\tncrazvan\catpaw\attributes\ApplicationScoped;
 use com\github\tncrazvan\catpaw\attributes\AttributeResolver;
 use com\github\tncrazvan\catpaw\attributes\database\Column;
 use com\github\tncrazvan\catpaw\attributes\database\Id;
+use com\github\tncrazvan\catpaw\attributes\database\IgnoreInsert;
+use com\github\tncrazvan\catpaw\attributes\database\IgnoreSelect;
+use com\github\tncrazvan\catpaw\attributes\database\IgnoreUpdate;
 use com\github\tncrazvan\catpaw\tools\helpers\Entity;
 use com\github\tncrazvan\catpaw\attributes\Entry;
 use com\github\tncrazvan\catpaw\attributes\Extend;
@@ -74,6 +77,9 @@ class Factory{
         $tableName = $entity->tableName();
         $entity->setTableName($tableName!==''?$tableName:\strtolower($reflection_class->getShortName()));
         $columns = [];
+        $columnsForInsert = [];
+        $columnsForUpdate = [];
+        $columnsForSelect = [];
         $pks = [];
         foreach($reflection_class->getProperties() as $reflection_property){
             $id = Id::findByProperty($reflection_property);
@@ -95,6 +101,14 @@ class Factory{
                 }
                 $columns[$colName] = $colType;
                 $pks[] = $colName;
+                $ignoreInsert = IgnoreInsert::findByProperty($reflection_property);
+                $ignoreUpdate = IgnoreUpdate::findByProperty($reflection_property);
+                $ignoreSelect = IgnoreSelect::findByProperty($reflection_property);
+                
+                if(!$ignoreInsert) $columnsForInsert[$colName] = $columns[$colName];
+                if(!$ignoreUpdate) $columnsForUpdate[$colName] = $columns[$colName];
+                if(!$ignoreSelect) $columnsForSelect[$colName] = $columns[$colName];
+                
             }else{
                 $column = Column::findByProperty($reflection_property);
                 if($column){
@@ -114,11 +128,21 @@ class Factory{
                         }
                     }
                     $columns[$colName] = $colType;
+                    $ignoreInsert = IgnoreInsert::findByProperty($reflection_property);
+                    $ignoreUpdate = IgnoreUpdate::findByProperty($reflection_property);
+                    $ignoreSelect = IgnoreSelect::findByProperty($reflection_property);
+                    
+                    if(!$ignoreInsert) $columnsForInsert[$colName] = $columns[$colName];
+                    if(!$ignoreUpdate) $columnsForUpdate[$colName] = $columns[$colName];
+                    if(!$ignoreSelect) $columnsForSelect[$colName] = $columns[$colName];
                 }
             }
         }
         
         $entity->setColumns($columns);
+        $entity->setColumnsForInsert($columnsForInsert);
+        $entity->setColumnsForUpdate($columnsForUpdate);
+        $entity->setColumnsForSelect($columnsForSelect);
         $entity->setPrimaryKeys($pks);
         $entity->reset_columns();
         


### PR DESCRIPTION
Added the following attributes for Entity Columns:
- ```IgnoreInsert```
- ```IgnoreUpdate```
- ```IgnoreSelect```

Each of these attributes make so that the column to which they are bound would be ignore in the given query context.

For example ```IgnoreUpdate``` makes it so that the column will not be considered when ```updating``` the entity, which results in actually ommitting the column from the built query sent to the database.

Consider the following entity:
```php
namespace examples\models;

use com\github\tncrazvan\catpaw\attributes\database\Column;
use com\github\tncrazvan\catpaw\attributes\database\Id;
use com\github\tncrazvan\catpaw\attributes\database\IgnoreUpdate;
use com\github\tncrazvan\catpaw\tools\helpers\Entity;
//use PDO;

#[Entity]
class Task{
    #[Id] public ?int $id = null;                   //null by default, so that mysql autoincrements is
                                                    //you can also specify the type  manually 
                                                    //by using #[ID(PDO::PARAM_**)]
    #[Column] public string $title = '';
    #[Column] public string $description = '';

    #[IgnoreUpdate]                                 //this will make it so that the `created` column
                                                    //will not be set when `update`ing the entity.
    #[Column] public int $created;
    #[Column] public int $updated;

    public function __construct(){
        $this->created = time();
        $this->updated = $this->created;
    }
}
```
In this case we want the ```created``` column to be initialized at the current ```time()```, but we don't want to update it's value in the database each time.

The attribute ```IgnoreUpdate``` solves that problem.