### PR TITLE
Pagination and minor changes to CrudRepository

### DIFF
--- a/examples/DBTasks.php
+++ b/examples/DBTasks.php
@@ -8,8 +8,10 @@ use com\github\tncrazvan\catpaw\attributes\http\methods\GET;
 use com\github\tncrazvan\catpaw\attributes\http\methods\POST;
 use com\github\tncrazvan\catpaw\attributes\http\methods\PUT;
 use com\github\tncrazvan\catpaw\attributes\http\Path;
+use com\github\tncrazvan\catpaw\attributes\http\PathParam;
 use com\github\tncrazvan\catpaw\attributes\Inject;
 use com\github\tncrazvan\catpaw\attributes\Produces;
+use com\github\tncrazvan\catpaw\qb\tools\Page;
 use com\github\tncrazvan\catpaw\tools\Status;
 use examples\filters\AssertTaskExists;
 use examples\filters\CheckTaskTitleLength;
@@ -63,7 +65,7 @@ class DBTasks{
     ):string{
         $task->id = null;                   //make sure the `id` is null so that mysql
                                             //will provide this value instead.
-        $repo->save($task);
+        $repo->insert($task);
         $status->setCode(Status::CREATED);
         return "Task added.";
     }
@@ -90,5 +92,29 @@ class DBTasks{
         $task->updated = time();
         $repo->update($task);           //update task
         return "Task updated.";
+    }
+
+
+
+    #[GET]
+    #[Path("/{id}")]
+    #[Produces("application/json")]
+    public function findById(
+        #[Inject] TaskRepository $repo,
+        #[PathParam] int $id
+    ):Generator|Task{
+        $task = yield $repo->findById($id);
+        return $task;
+    }
+
+    #[GET]
+    #[Path("/page/{offset}")]
+    #[Produces("application/json")]
+    public function findTasksPage(
+        #[Inject] TaskRepository $repo,
+        #[PathParam] int $offset
+    ):Generator|array{
+        $tasks = yield $repo->findAll(Page::of($offset,3));
+        return $tasks;
     }
 }

--- a/examples/repositories/TaskRepository.php
+++ b/examples/repositories/TaskRepository.php
@@ -2,10 +2,11 @@
 namespace examples\repositories;
 
 use com\github\tncrazvan\catpaw\attributes\Repository;
-use com\github\tncrazvan\catpaw\qb\operations\Operation;
 use com\github\tncrazvan\catpaw\qb\tools\Column;
+use com\github\tncrazvan\catpaw\qb\tools\Page;
 use com\github\tncrazvan\catpaw\tools\helpers\CrudRepository;
 use examples\models\Task;
+use React\Promise\Promise;
 
 #[Repository(Task::class)]          //specify that this is a repository for the `Todo` model.
                                     //this way the repository knows whic tables to query and what

--- a/src/com/github/tncrazvan/catpaw/HttpInvoker.php
+++ b/src/com/github/tncrazvan/catpaw/HttpInvoker.php
@@ -446,7 +446,7 @@ class HttpInvoker{
                     $args[] = \filter_var($http_params[$name] || false, FILTER_VALIDATE_BOOLEAN);
                 break;
                 case 'string':
-                    if(!$http_params[$name]){
+                    if(!isset($http_params[$name])){
                         if($optional)
                             $args[] = $__ARG__->getDefaultValue();
                         else
@@ -455,7 +455,7 @@ class HttpInvoker{
                         $args[] = &$http_params[$name];
                 break;
                 case 'int':
-                    if(!$http_params[$name]){
+                    if(!isset($http_params[$name])){
                         if($optional)
                             $args[] = $__ARG__->getDefaultValue();
                         else
@@ -469,7 +469,7 @@ class HttpInvoker{
                     }
                 break;
                 case 'float':
-                    if(!$http_params[$name]){
+                    if(!isset($http_params[$name])){
                         if($optional)
                             $args[] = $__ARG__->getDefaultValue();
                         else

--- a/src/com/github/tncrazvan/catpaw/qb/tools/Page.php
+++ b/src/com/github/tncrazvan/catpaw/qb/tools/Page.php
@@ -1,0 +1,66 @@
+<?php
+namespace com\github\tncrazvan\catpaw\qb\tools;
+
+use Exception;
+
+class Page{
+    private function __construct(
+        private int $offset,
+        private int $size,
+        private bool $sqlsrv
+    ){
+        if($size <= 0)
+            throw new Exception("Size of page cannot be 0 or less.");
+        if($offset < 0)
+            throw new Exception("Offset of page cannot be less then 0");
+    }
+
+    public function isSqlsrv():bool{
+        return $this->isSqlsrv();
+    }
+
+    /**
+     * Get the **offset** of this page.
+     * Note: offsets start from 0.
+     */
+    public function getNextOffset():int{
+        return $this->size * $this->offset;
+    }
+
+    /**
+     * Get the **maximum number of elements** this page can contain.
+     */
+    public function getSize():int{
+        return $this->size;
+    }
+
+    /**
+     * Get both the **offset** and the **size** of the page as an array (**in that order**).
+     * @return array offset and size of the page
+     */
+    public function get():array{
+        return [
+            $this->size * $this->offset,
+            $this->size
+        ];
+    }
+
+    /**
+     * Make a new Page of size **$size** that starts at offset 0.
+     * @param int $size maximum number of elements the page can contain.
+     * @return Page the newly created page object.
+     */
+    public static function ofSize(int $size, bool $sqlsrv = false):Page{
+        return new Page(0,$size,$sqlsrv);
+    }
+
+    /**
+     * Make a new Page of size **$size** that starts at offset **$offset**.
+     * @param int $offset offset of the page (starting from 0).
+     * @param int $size maximum number of elements the page can contain.
+     * @return Page the newly created page object.
+     */
+    public static function of(int $offset, int $size, bool $sqlsrv = false):Page{
+        return new Page($offset,$size,$sqlsrv);
+    }
+}

--- a/src/com/github/tncrazvan/catpaw/qb/tools/QueryBuilder.php
+++ b/src/com/github/tncrazvan/catpaw/qb/tools/QueryBuilder.php
@@ -12,6 +12,7 @@ use com\github\tncrazvan\catpaw\qb\traits\Delete;
 use com\github\tncrazvan\catpaw\qb\traits\Insert;
 use com\github\tncrazvan\catpaw\qb\traits\Select;
 use com\github\tncrazvan\catpaw\qb\traits\Update;
+use com\github\tncrazvan\catpaw\qb\traits\Limit;
 use React\EventLoop\LoopInterface;
 use React\Promise\Promise;
 
@@ -24,6 +25,7 @@ class QueryBuilder implements QueryConst{
     use Insert;
     use Update;
     use Delete;
+    use Limit;
     
     //private $database;
     private $query = "";

--- a/src/com/github/tncrazvan/catpaw/qb/tools/QueryConst.php
+++ b/src/com/github/tncrazvan/catpaw/qb/tools/QueryConst.php
@@ -33,6 +33,7 @@ interface QueryConst{
         LESSER_THAN_EQUAL = '<=',
         EQUALS = '=',
         LIKE = 'like',
-        BETWEEN = 'between'
+        BETWEEN = 'between',
+        LIMIT = 'limit'
     ;
 }

--- a/src/com/github/tncrazvan/catpaw/qb/traits/Clause.php
+++ b/src/com/github/tncrazvan/catpaw/qb/traits/Clause.php
@@ -98,7 +98,7 @@ trait Clause{
         $operation = $callback->run($column);
         $value = $operation->getValue();
         $length = count($value);
-        $random = \uniqid();
+        $random = \uniqid().'c';
 
         //clean "." in binding name because
         //the "." character in binding a name triggers a SQL syntax error

--- a/src/com/github/tncrazvan/catpaw/qb/traits/Insert.php
+++ b/src/com/github/tncrazvan/catpaw/qb/traits/Insert.php
@@ -106,7 +106,7 @@ trait Insert{
         foreach($columns as $name => &$o){
             if($first) $first = false;
             else $this->add(QueryConst::COMMA);
-            $random = \uniqid();
+            $random = \uniqid().'i';
             $this->add(QueryConst::VARIABLE_SYMBOL.$name.$random);
             $type = $columns[$name]->getColumnType();
             switch($type){

--- a/src/com/github/tncrazvan/catpaw/qb/traits/Limit.php
+++ b/src/com/github/tncrazvan/catpaw/qb/traits/Limit.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace com\github\tncrazvan\catpaw\qb\traits;
+
+use com\github\tncrazvan\catpaw\qb\tools\Binding;
+use com\github\tncrazvan\catpaw\qb\tools\Page;
+use com\github\tncrazvan\catpaw\qb\tools\QueryBuilder;
+use com\github\tncrazvan\catpaw\qb\tools\QueryConst;
+
+trait Limit{
+    /**
+     * Set a window limit for the result.
+     * @param int $offset offset of the result.
+     * @param int $length maximum length of the result.
+     * @return QueryBuilder the QueryBuilder
+     */
+    public function limit(int $offset, ?int $length = null):QueryBuilder{
+        $randomo = \uniqid().'lo';
+        $randoml = \uniqid().'ll';
+        $name = 'lim';
+
+        $this->add(QueryConst::LIMIT);
+
+        $this->add(QueryConst::VARIABLE_SYMBOL.$name.$randomo);
+        $this->bind($name.$randomo,new Binding($offset,\PDO::PARAM_INT));
+
+        if($length !== null){
+            $this->add(QueryConst::COMMA);
+            $this->add(QueryConst::VARIABLE_SYMBOL.$name.$randoml);
+            $this->bind($name.$randoml,new Binding($length,\PDO::PARAM_INT));
+        }
+
+        return $this;
+    }
+
+    /**
+     * Request a page from the result.
+     * @param Page $page page details.
+     * @return QueryBuilder the QueryBuilder
+     */
+    public function page(Page $page):QueryBuilder{
+        $this->limit(...$page->get());
+        return $this;
+    }
+}

--- a/src/com/github/tncrazvan/catpaw/qb/traits/Update.php
+++ b/src/com/github/tncrazvan/catpaw/qb/traits/Update.php
@@ -35,7 +35,7 @@ trait Update{
             }
             $this->add($name);
             $this->add(QueryConst::EQUALS);
-            $random = \uniqid();
+            $random = \uniqid().'u';
             $this->add(QueryConst::VARIABLE_SYMBOL.$name.$random);
             $type = $columns[$name]->getColumnType();
             switch($type){

--- a/src/com/github/tncrazvan/catpaw/tools/helpers/CrudRepository.php
+++ b/src/com/github/tncrazvan/catpaw/tools/helpers/CrudRepository.php
@@ -4,6 +4,7 @@ namespace com\github\tncrazvan\catpaw\tools\helpers;
 use com\github\tncrazvan\catpaw\attributes\Inject;
 use com\github\tncrazvan\catpaw\tools\helpers\SimpleQueryBuilder;
 use com\github\tncrazvan\catpaw\qb\tools\Column;
+use com\github\tncrazvan\catpaw\qb\tools\Page;
 use React\Promise\Promise;
 
 class CrudRepository{
@@ -11,41 +12,49 @@ class CrudRepository{
     #[Inject]
     protected SimpleQueryBuilder $builder;
 
-    public function findAll():Promise{
-        return $this
-            ->builder
-            ->select($this->classname)
-            ->fetchAssoc();
+    public function findAll(?Page $page = null):Promise{
+        $query = 
+                $this
+                ->builder
+                ->select($this->classname);
+        
+        if($page)
+            $query->limit(...$page->get());
+
+        return $query->fetchAssoc();
     }
 
-    public function findById(mixed $id):Promise{
-        $b = 
-        $this->builder
-        ->select($this->classname)
-        ->where();
+    public function findById(string|int|float|bool|null $id,?Page $page = null):Promise{
+        $query = 
+            $this->builder
+            ->select($this->classname)
+            ->where();
 
         foreach($this->id as &$i){
-            $b->column($i, Column::EQUALS, $id);
+            $query->column($i, Column::EQUALS, $id);
         }
 
-        return $b->fetchObject($this->classname);
+        if($page)
+            $query->limit(...$page->get());
+
+        return $query->fetchObject($this->classname);
     }
 
-    public function deleteById(mixed $id):void{
-        $b = 
+    public function deleteById(string|int|float|bool|null $id):void{
+        $query = 
         $this
             ->builder
             ->delete($this->classname)
             ->where();
 
         foreach($this->id as &$i){
-            $b->column($i, Column::EQUALS, $id);
+            $query->column($i, Column::EQUALS, $id);
         }
-
-        $b->execute(-1);
+        
+        $query->execute(-1);
     }
 
-    public function save(object $object):void{
+    public function insert(object $object):void{
         $this
             ->builder
             ->insert($this->classname, $object)


### PR DESCRIPTION
You can now use pagination for queries and CrudRepository::save has been renamed to CrudRepository::insert since it only inserts and doesn't actually manage updates.

Here's an example of pagination:

```php
    #[GET]
    #[Path("/page/{offset}")]
    #[Produces("application/json")]
    public function findTasksPage(
        #[Inject] TaskRepository $repo,
        #[PathParam] int $offset
    ):Generator|array{
        $tasks = yield $repo->findAll(Page::of($offset,3));
        return $tasks;
    }
```

And if you want to build your own queries:

```php
class TaskRepository extends CrudRepository {

        public function test():Promise{
            return $this
                ->builder
                ->select(Task::class)
                ->limit(...Page::ofSize(3)->get())
                ->fetchAssoc()
                ;
        }
}
```