### PR TITLE
Query result object mapping improved

### DIFF
--- a/examples/DBTasks.php
+++ b/examples/DBTasks.php
@@ -39,7 +39,7 @@ class DBTasks{
         #[Inject] TaskRepository $repo      //inject the repository
     ):Generator|array{                      //specify it's a generator so that intellisense won't scream at you
         
-        $tasks = yield $repo->findAll();    //find the todos from the database and `yield`.
+        $tasks = yield $repo->findAll(Task::class);    //find the todos from the database and `yield`.
                                             //`yield`ing will make it so the server will convert the 
                                             //response of this method to a `Promise` in the background.
                                             //This means that from this point on your method has become

--- a/src/com/github/tncrazvan/catpaw/tools/helpers/CrudRepository.php
+++ b/src/com/github/tncrazvan/catpaw/tools/helpers/CrudRepository.php
@@ -13,7 +13,7 @@ class CrudRepository{
     #[Inject]
     protected SimpleQueryBuilder $builder;
 
-    public function findAll():Promise{
+    public function findAll(string $classname = ''):Promise{
         $query = 
                 $this
                 ->builder
@@ -23,8 +23,8 @@ class CrudRepository{
             $query->limit(...$this->pg->get());
             $this->pg = null;
         }
-
-        return $query->fetchAssoc();
+        
+        return $classname !== ''?$query->fetchObjects($classname):$query->fetchAssoc();
     }
 
     private function match_pks(QueryBuilder $query, object $model):void{
@@ -55,7 +55,7 @@ class CrudRepository{
             $this->pg = null;
         }
 
-        return $query->fetchObject($this->classname);
+        return $query->fetchObjects($this->classname)->then(fn($items)=>$items[0]??null);
     }
 
     public function delete(object $object):Promise{


### PR DESCRIPTION
```QueryBuilder::fetchObject``` renamed to ```QueryBuilder::fetchObjects``` and now returns an array of items instead of one single item.

This means you can now fetch multiple rows as objects instead of associative arrays.