### PR TITLE
Variable paths priority

### DIFF
--- a/examples/DBTasks.php
+++ b/examples/DBTasks.php
@@ -9,6 +9,7 @@ use com\github\tncrazvan\catpaw\attributes\http\methods\POST;
 use com\github\tncrazvan\catpaw\attributes\http\methods\PUT;
 use com\github\tncrazvan\catpaw\attributes\http\Path;
 use com\github\tncrazvan\catpaw\attributes\http\PathParam;
+use com\github\tncrazvan\catpaw\attributes\http\Query;
 use com\github\tncrazvan\catpaw\attributes\http\RequestHeaders;
 use com\github\tncrazvan\catpaw\attributes\Inject;
 use com\github\tncrazvan\catpaw\attributes\Produces;
@@ -109,11 +110,11 @@ class DBTasks{
     }
 
     #[GET]
-    #[Path("/page/{offset}")]
+    #[Path("/page")]
     #[Produces("application/json")]
     public function findTasksPage(
         #[Inject] TaskRepository $repo,
-        #[PathParam] int $offset
+        #[Query("offset")] int $offset
     ):Generator|array{
         $tasks = yield $repo->page(Page::of($offset,3))->findAll(Task::class);
         return $tasks;

--- a/src/com/github/tncrazvan/catpaw/attributes/http/Query.php
+++ b/src/com/github/tncrazvan/catpaw/attributes/http/Query.php
@@ -1,0 +1,17 @@
+<?php
+namespace com\github\tncrazvan\catpaw\attributes\http;
+
+use com\github\tncrazvan\catpaw\attributes\interfaces\AttributeInterface;
+use com\github\tncrazvan\catpaw\attributes\traits\CoreAttributeDefinition;
+
+#[\Attribute]
+class Query implements AttributeInterface{
+    use CoreAttributeDefinition;
+    public function __construct(
+        private string $name
+    ){}
+
+    public function getName():string{
+        return $this->name;
+    }
+}

--- a/src/com/github/tncrazvan/catpaw/tools/helpers/Route.php
+++ b/src/com/github/tncrazvan/catpaw/tools/helpers/Route.php
@@ -7,6 +7,7 @@ use com\github\tncrazvan\catpaw\attributes\Filter;
 use com\github\tncrazvan\catpaw\attributes\http\ResponseHeaders;
 use com\github\tncrazvan\catpaw\attributes\http\Path;
 use com\github\tncrazvan\catpaw\attributes\http\PathParam;
+use com\github\tncrazvan\catpaw\attributes\http\Query;
 use com\github\tncrazvan\catpaw\attributes\http\RequestHeaders;
 use com\github\tncrazvan\catpaw\attributes\Inject;
 use com\github\tncrazvan\catpaw\attributes\Produces;
@@ -96,6 +97,7 @@ class Route{
             Meta::$METHODS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Body::class] = Body::findByParameter($param);
             Meta::$METHODS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Request::class] = Request::findByParameter($param);
             Meta::$METHODS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Inject::class] = Inject::findByParameter($param);
+            Meta::$METHODS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Query::class] = Query::findByParameter($param);
         }
     }
     private static function initialize_function(
@@ -132,6 +134,7 @@ class Route{
             Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Body::class] = Body::findByParameter($param);
             Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Request::class] = Request::findByParameter($param);
             Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Inject::class] = Inject::findByParameter($param);
+            Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Query::class] = Query::findByParameter($param);
         }
     }
     private static function initialize_filter(
@@ -160,6 +163,7 @@ class Route{
             Meta::$FILTERS_ARGS_ATTRIBUTES[$method][$path][$classname][$param->getName()][Body::class] = Body::findByParameter($param);
             Meta::$FILTERS_ARGS_ATTRIBUTES[$method][$path][$classname][$param->getName()][Request::class] = Request::findByParameter($param);
             Meta::$FILTERS_ARGS_ATTRIBUTES[$method][$path][$classname][$param->getName()][Inject::class] = Inject::findByParameter($param);
+            Meta::$FILTERS_ARGS_ATTRIBUTES[$method][$path][$classname][$param->getName()][Query::class] = Query::findByParameter($param);
         }
     }
     private static function initialize(


### PR DESCRIPTION
Variable paths now have lower priority than static paths.

In the following example both endpoints can match the same path:
```php
    #[GET]
    #[Path("/{id}")]
    #[Produces("application/json")]
    public function findById(
        #[Inject] TaskRepository $repo,
        #[PathParam] int $id
    ):Generator|Task{
        $task = yield $repo->findById($id);
        return $task;
    }

    #[GET]
    #[Path("/page")]
    #[Produces("application/json")]
    public function findTasksPage(
        #[Inject] TaskRepository $repo,
        #[Query("offset")] int $offset
    ):Generator|array{
        $tasks = yield $repo->page(Page::of($offset,3))->findAll(Task::class);
        return $tasks;
    }
```

But method ```findTasksPage``` will always have priority over ```findById```, and that's because "/page" is a static paths name which doesn't involve the use of path parameters.