### PR TITLE
path matching improved

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 	"require": {
 		"php": ">=8.0",
 		"razshare/asciitable": ">=1.0.4",
-		"react/react": "^1.0.1"
+		"react/react": "^1.0.1",
+		"react/child-process": "^0.6.2"
 	},
 	"config": {
 		"preferred-install": "dist"

--- a/examples/ProcessTest.php
+++ b/examples/ProcessTest.php
@@ -19,7 +19,7 @@ class ProcessTest{
     #[Path("/{message}")]
     public function start(
         #[Inject] LoopInterface $loop,
-        #[PathParam] string $message,
+        #[PathParam] string $message = 'hello from child',
         #[Query] int $sleep = 3
     ):Generator|string{
         $message = yield new Promise(function($r) use(&$loop,&$message,&$sleep){

--- a/examples/ProcessTest.php
+++ b/examples/ProcessTest.php
@@ -1,0 +1,45 @@
+<?php
+namespace examples;
+
+use Exception;
+use Generator;
+use net\razshare\catpaw\attributes\http\methods\GET;
+use net\razshare\catpaw\attributes\http\Path;
+use net\razshare\catpaw\attributes\http\PathParam;
+use net\razshare\catpaw\attributes\http\Query;
+use net\razshare\catpaw\attributes\Inject;
+use React\ChildProcess\Process;
+use React\EventLoop\LoopInterface;
+use React\Promise\Promise;
+
+#[Path("/child-process")]
+class ProcessTest{
+
+    #[GET]
+    #[Path("/{message}")]
+    public function start(
+        #[Inject] LoopInterface $loop,
+        #[PathParam] string $message,
+        #[Query] int $sleep = 3
+    ):Generator|string{
+        $message = yield new Promise(function($r) use(&$loop,&$message,&$sleep){
+            $dir = dirname(__FILE__).'/files';
+            if(!is_dir($dir) && !is_file($dir))
+                mkdir($dir,0777,true);
+
+            $process = new Process("sleep $sleep && echo $message");
+            $process->start($loop);
+            $message = '';
+            $process->stdout->on('data', function ($chunk) use(&$message){
+                $message .=$chunk;
+            });
+            $process->on("exit",function() use(&$r,&$message){
+                $r($message);
+            });
+            $process->stdout->on('error', function (Exception $e) use(&$r){
+                $r($e);
+            });
+        });
+        return $message;
+    }
+}

--- a/main.php
+++ b/main.php
@@ -34,6 +34,7 @@ Factory::make(\examples\Starter::class);
 Factory::make(\examples\repositories\TaskRepository::class);
 Factory::make(\examples\models\Task::class);
 Factory::make(\examples\DBTasks::class);
+Factory::make(\examples\ProcessTest::class);
 
 //create and start server
 $server = new CatPaw(new class extends MainConfiguration{

--- a/src/net/razshare/catpaw/CatPaw.php
+++ b/src/net/razshare/catpaw/CatPaw.php
@@ -111,16 +111,18 @@ class CatPaw{
         if(!isset($_map[$method])) 
             return null;
         foreach($_map[$method] as $local_path => $item){
-            $path_pattern = Meta::$HTTP_METHODS_PATHS_PATTERNS[$method][$local_path];
-            $matching = \preg_match($path_pattern,$requested_path,$values);
-            if($matching){
-                if(\preg_match_all('/(?<={)[\w\d\-_\.\~]+(?=})/',$local_path,$names)){
-                    $l = \count($values);
-                    for($i=1;$i<$l;$i++){
-                        $params[$names[0][$i-1]] = \urldecode($values[$i]);
+            $path_patterns = Meta::$HTTP_METHODS_PATHS_PATTERNS[$method][$local_path];
+            foreach($path_patterns as $path_pattern){
+                $matching = \preg_match($path_pattern,$requested_path,$values);
+                if($matching){
+                    if(\preg_match_all('/(?<={)[\w\d\-_\.\~]+(?=})/',$local_path,$names)){
+                        $l = \count($values);
+                        for($i=1;$i<$l;$i++){
+                            $params[$names[0][$i-1]] = \urldecode($values[$i]);
+                        }
                     }
+                    return $local_path;
                 }
-                return $local_path;
             }
         }
         return null;

--- a/src/net/razshare/catpaw/CatPaw.php
+++ b/src/net/razshare/catpaw/CatPaw.php
@@ -111,25 +111,13 @@ class CatPaw{
         if(!isset($_map[$method])) 
             return null;
         foreach($_map[$method] as $local_path => $item){
-            $path_pattern = '/^'.\preg_replace(
-                [
-                    '/\//',
-                    '/\./',
-                    '/{[\w\d\-_\.\~]+}/',
-                ],
-                [
-                    '\/',
-                    '\.',
-                    '([\w\d\-_\.\~]+)',
-                ],
-                $local_path
-            ).'$/';
+            $path_pattern = Meta::$HTTP_METHODS_PATHS_PATTERNS[$method][$local_path];
             $matching = \preg_match($path_pattern,$requested_path,$values);
             if($matching){
                 if(\preg_match_all('/(?<={)[\w\d\-_\.\~]+(?=})/',$local_path,$names)){
                     $l = \count($values);
                     for($i=1;$i<$l;$i++){
-                        $params[$names[0][$i-1]] = $values[$i];
+                        $params[$names[0][$i-1]] = \urldecode($values[$i]);
                     }
                 }
                 return $local_path;

--- a/src/net/razshare/catpaw/attributes/http/PathParam.php
+++ b/src/net/razshare/catpaw/attributes/http/PathParam.php
@@ -7,4 +7,15 @@ use net\razshare\catpaw\attributes\traits\CoreAttributeDefinition;
 #[\Attribute]
 class PathParam implements AttributeInterface{
     use CoreAttributeDefinition;
+
+    public function __construct(
+        private string $regex = '[\w\d\-_\.\~%]+'
+    ){}
+
+    public function getRegex():string{
+        return $this->regex;
+    }
+    public function setRegex(string $regex):void{
+        $this->regex = $regex;
+    }
 }

--- a/src/net/razshare/catpaw/attributes/http/Query.php
+++ b/src/net/razshare/catpaw/attributes/http/Query.php
@@ -8,9 +8,12 @@ use net\razshare\catpaw\attributes\traits\CoreAttributeDefinition;
 class Query implements AttributeInterface{
     use CoreAttributeDefinition;
     public function __construct(
-        private string $name
+        private string $name = ''
     ){}
 
+    public function setName(string $name):void{
+        $this->name = $name;
+    }
     public function getName():string{
         return $this->name;
     }

--- a/src/net/razshare/catpaw/attributes/metadata/Meta.php
+++ b/src/net/razshare/catpaw/attributes/metadata/Meta.php
@@ -5,6 +5,8 @@ namespace net\razshare\catpaw\attributes\metadata;
 class Meta{
     public static $PATH_PARAMS = [];
 
+    public static array $HTTP_METHODS_PATHS_PATTERNS = [];
+
     public static array $METHODS = [];
     public static array $METHODS_ATTRIBUTES = [];
 

--- a/src/net/razshare/catpaw/tools/helpers/Factory.php
+++ b/src/net/razshare/catpaw/tools/helpers/Factory.php
@@ -267,20 +267,11 @@ class Factory{
         if(!str_starts_with($base_path,'/'))
             $base_path = "/$base_path";
             
-        if($singleton){
-            Route::map(
-                $reflection_class,
-                $base_path,
-                $map
-            );
-        }else {
-            $factory = Factory::class;
-            Route::map(
-                $reflection_class,
-                $base_path,
-                $map
-            );
-        }
+        Route::map(
+            $reflection_class,
+            $base_path,
+            $map
+        );
     }
 
     private static function entry(array &$methods,mixed $instance,string &$classname):void{

--- a/src/net/razshare/catpaw/tools/helpers/Route.php
+++ b/src/net/razshare/catpaw/tools/helpers/Route.php
@@ -141,7 +141,7 @@ class Route{
                 $query->setName($param->getName());
             Meta::$METHODS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Query::class] = $query;
         }
-        Meta::$HTTP_METHODS_PATHS_PATTERNS[$method][$path] = static::getPathPattern($path,$params);
+        Meta::$HTTP_METHODS_PATHS_PATTERNS[$method][$path][] = static::getPathPattern($path,$params);
     }
     private static function initialize_function(
         string &$method, 
@@ -195,7 +195,7 @@ class Route{
             Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Query::class] = $query;
         }
         
-        Meta::$HTTP_METHODS_PATHS_PATTERNS[$method][$path] = static::getPathPattern($path,$params);
+        Meta::$HTTP_METHODS_PATHS_PATTERNS[$method][$path][] = static::getPathPattern($path,$params);
     }
     private static function initialize_filter(
         string $method,

--- a/src/net/razshare/catpaw/tools/helpers/Route.php
+++ b/src/net/razshare/catpaw/tools/helpers/Route.php
@@ -47,6 +47,45 @@ class Route{
             static::initialize($method,$path,$reflection_class,$reflection_method,null);
         }
     }
+
+    private static function getPathPattern(
+        string &$path,
+        array &$params
+    ):string{
+        $toSearch = [
+            '/\//',
+            '/\./',
+        ];
+        $toReplace = [
+            '\/',
+            '\.',
+        ];
+        foreach($params as $param){
+            $path_param = PathParam::findByParameter($param);
+            if($path_param){
+                $optional = $param->isOptional();
+                $type = $param->getType()->getName();
+                switch($type){
+                    case 'int':
+                        $path_param->setRegex('[0-9]+');
+                    break;
+                    case 'float':
+                        $path_param->setRegex('[0-9]+\.[0-9]+');
+                    break;
+                }
+                $toSearch[] = '/{'.$param->getName().'}/';
+                $toReplace[] = ($optional?'?':'').'('.$path_param->getRegex().')'.($optional?'?':'');
+            }
+        }
+
+        $path_pattern = '/^'.\preg_replace(
+            $toSearch,
+            $toReplace,
+            $path
+        ).'$/';
+        return $path_pattern;
+    }
+
     private static function initialize_class(
         string &$method, 
         string &$path, 
@@ -86,7 +125,7 @@ class Route{
         Meta::$METHODS_ATTRIBUTES[$method][$path][Produces::class] = Produces::findByMethod($reflection_method);
         if(!Meta::$METHODS_ATTRIBUTES[$method][$path][Produces::class])
             Meta::$METHODS_ATTRIBUTES[$method][$path][Produces::class] = new Produces("text/plain");
-        
+
         foreach($params as $param){
             $path_param = PathParam::findByParameter($param);
             Meta::$PATH_PARAMS[$method][$path][$param->getName()] = $path_param;
@@ -97,8 +136,12 @@ class Route{
             Meta::$METHODS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Body::class] = Body::findByParameter($param);
             Meta::$METHODS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Request::class] = Request::findByParameter($param);
             Meta::$METHODS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Inject::class] = Inject::findByParameter($param);
-            Meta::$METHODS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Query::class] = Query::findByParameter($param);
+            $query = Query::findByParameter($param);
+            if($query && '' === $query->getName())
+                $query->setName($param->getName());
+            Meta::$METHODS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Query::class] = $query;
         }
+        Meta::$HTTP_METHODS_PATHS_PATTERNS[$method][$path] = static::getPathPattern($path,$params);
     }
     private static function initialize_function(
         string &$method, 
@@ -126,6 +169,18 @@ class Route{
         
         foreach($params as $param){
             $path_param = PathParam::findByParameter($param);
+            $type = $param->getType()->getName();
+            switch($type){
+                case 'int':
+                    $path_param->setRegex('/[0-9]+/');
+                break;
+                case 'float':
+                    $path_param->setRegex('/[0-9]+\.[0-9]+/');
+                break;
+                default:
+                    $path_param->setRegex('/.+/');
+                break;
+            }
             Meta::$PATH_PARAMS[$method][$path][$param->getName()] = $path_param;
             Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][ResponseHeaders::class] = ResponseHeaders::findByParameter($param);
             Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][RequestHeaders::class] = RequestHeaders::findByParameter($param);
@@ -134,8 +189,13 @@ class Route{
             Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Body::class] = Body::findByParameter($param);
             Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Request::class] = Request::findByParameter($param);
             Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Inject::class] = Inject::findByParameter($param);
-            Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Query::class] = Query::findByParameter($param);
+            $query = Query::findByParameter($param);
+            if($query && '' === $query->getName())
+                $query->setName($param->getName());
+            Meta::$FUNCTIONS_ARGS_ATTRIBUTES[$method][$path][$param->getName()][Query::class] = $query;
         }
+        
+        Meta::$HTTP_METHODS_PATHS_PATTERNS[$method][$path] = static::getPathPattern($path,$params);
     }
     private static function initialize_filter(
         string $method,


### PR DESCRIPTION
Path matching has been improved and now supports optional parameters.
There is no additional syntax to learn, simply provide a default value for your parameters and they will be interpreted as optional.

Take for instance the new ```Process``` example:
https://github.com/tncrazvan/catpaw/blob/f5d580797f5b16ea5898ec89f1a0e7857b467031/examples/ProcessTest.php#L18-L44

The ```$message``` path parameter provides a default value of ```hello from child```, that means the path parameter is optional.
You can now also provide a custom regex for matching your parameters using the ```PathParam``` attribute, like this:
```php
#[PathParam('[A-Z]+')]
string $message = 'HELLO FROM CHILD',
```
In this case ```$message``` would only match upper case strings.

---

Suppose you have 2 endpoints with identical absolute names:
1. ```/process/{id}```
2. ```/process/{id}```

But endpoint ```1``` differs from endpoint ```2``` in that it only accepts numeric values as parameter, so the param definitions would look like this:

1. For the first endpoint
```php
#[PathParam('[0-7]+')] int $id
```
1. For the second endpoint
```php
#[PathParam] string $id
```

### How would the requests be resolved?
For the sake of this example immagine our endpoints are both ```GET``` endpoints, and there's an incoming request for one of those 2 endpoints (we don't know which one yet).

When 2 endpoints have the same exact signature path (```/process/{id}```), the ending will throw both of them in one array and will resolve which one to invoke at runtime when the request hits the server.

So given the request ```GET /process/abcd```, the server will
1. try to match the pattern ```/process/[0-7]+```
which will fail
2. then it will try to match ```/process/[\w\d\-_\.\~%]+```
which is the default pattern for ```string``` types.
This pattern will match and the server will serve the request accordingly.

---

As mentioned above ```string``` types have a default pattern of ```[\w\d\-_\.\~%]+``` which you can obviously overwrite.
Integer types also have a default pattern which is ```[0-9]+```.
The same goes for floats: ```[0-9]+\.[0-9]+```.

You can customize al 3 of these types as you see fit using ```PathParam('...')```.